### PR TITLE
Add Datadog (part of Github Education Pack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Table of Contents
   * [Game Development Tools](#game-development-tools)
   * [3D Animation and Modeling Software](#3d-animation-and-modeling-software)
   * [Password Managers](#password-managers)
+  * [Infrastructure Monitoring](#infrastructure-monitoring)
   * [Other Packs](#other-packs)
 
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Table of Contents
 
  * [LastPass](https://lastpass.com/edupromo.php) - Enjoy 6 months of LastPass Premium to help you manage your online life at school!
 
+## Infrastructure Monitoring
+ * [Datadog](http://studentpack.datadoghq.com/) - 2-Year License for a Datadog Pro account, good for monitoring 10 servers. Part of the [Github Student Developer Pack](https://education.github.com/pack)
+
 ## Software Packs
 
   * [Microsoft Imagine (formerly DreamSpark)](https://imagine.microsoft.com/) - Imagine is a Microsoft program that supports technical education by providing access to Microsoft software for learning, teaching and research purposes. Currently includes SQL Server 2012, 2014, and 2016; Windows Server 2008 R2, 2012 R2, and 2016 in DataCenter, Standard, and Essentials and Windows 8.1 Embedded Industry Pro. Also offers a free Azure App service plan (no credit card). Most students are also eligible for a free Windows 10 license through their school's [OnTheHub WebStore](http://onthehub.com/download/free-software/windows-10-education-for-students/).


### PR DESCRIPTION
Add Datadog's offer of a free 2-year pro account as part of the Github Education Pack.

It's a pretty major infrastructure monitoring service (akin to say NewRelic) and it's nice that students have access to it for 2 years.