### PR TITLE
Update Semaphore documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Table of Contents
 
   * [Travis CI](https://travis-ci.org) [FREE] - Private builds (normally $69/month) while you're a student available via [Github Student Developer Pack](https://education.github.com/pack).
   * [StyleCI](https://blog.alt-three.com/introducing-the-student-plan/) [FREE / CREDIT] - Free Student Plan with access to StyleCI for up to five private repositories.
-  * [Semaphore](http://semaphoreci.com/docs/education-plans.html) [FREE / DISCOUNT]- Free account for students and educators with a 25% discount for qualifying schools and institutions.
+  * [Semaphore](https://docs.semaphoreci.com/account-management/discounts/) [FREE / DISCOUNT]- Free account for students and educators with a 25% discount for qualifying schools and institutions.
 
 ## Payments
 


### PR DESCRIPTION
It pointed to the previous version of Semaphore.