### PR TITLE
Remove yellowcircle and nodehost offers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ Table of Contents
 
 * [Education Host](https://education.github.com/pack) [FREE] - 50% web hosting for the first year for students. Available via [Github Student Developer Pack](https://education.github.com/pack).
 
-* [NodeHost](https://nodehost.ca/education) [FREE] - PHP hosting. 500MB Storage, 80GB Bandwidth, 1 Database, and 2 email accounts per site, 28 day backup history.
-
 * [Pageclip](https://pageclip.co/github-students) [FREE] - A server for your static websites and HTML forms. Free basic plan while you are a student.
 
 * [Qoddi](https://qoddi.com) [CREDIT] - Qoddi offers $250 per year for [every student](https://blog.qoddi.com/flashdrive-student-program/) when you are approved
@@ -206,8 +204,6 @@ Table of Contents
 ## Management Systems
 
   * [Bitnami](https://bitnami.com) [FREE] - Install cloud applications in a single click. Business 3 plan (normally $49/month) for one year available via [Github Student Developer Pack](https://education.github.com/pack).
-
-* [Yellow Circle](https://yellowcircle.net) [FREE] - Offers a free online sandbox for students and teachers at all levels to learn and practice IT, networking, and programming skills by creating and configuring virtual routers, virtual machines, and virtual firewalls, load-balancers, and storage devices.
 
 * [Vertabelo](https://www.vertabelo.com/) [FREE] - Fully-featured online tool for database design. Free for Educational Purposes.
 


### PR DESCRIPTION
You can check both offers do not exist anymore.
1. nodehost: https://nodehost.ca/education
Is showes 404 Page not found.
2. yellowcircle: Over the last 8 years Yellow Circle provided a free technology platform to over 300,000 students and teachers from around the world. Our team is sincerely thankful to all of your support in the past and look forward to working with you on future projects. As of October 15, 2022 the virtual learning platform is officially retired.